### PR TITLE
Update Secure Message demo to dev-210

### DIFF
--- a/SaifeMessageDemo/java/src/com/saife/sample/MainFrameLauncher.java
+++ b/SaifeMessageDemo/java/src/com/saife/sample/MainFrameLauncher.java
@@ -68,7 +68,7 @@ public class MainFrameLauncher {
      *
      */
     public void launchEF() {
-        handler.logInfo("Launching Error Frame");
+        System.out.println("Launching Error Frame");
 
         if (null == ml) {
             ml = new MainFrameLauncher();
@@ -82,7 +82,7 @@ public class MainFrameLauncher {
                     @SuppressWarnings("unused")
                     final MainFrame window = new MainFrame(ml);
                 } catch (final Exception e) {
-                    handler.logError("SAIFE encountered an exception: "
+                    System.out.println("SAIFE encountered an exception: "
                         + e.getMessage());
                 }
             }


### PR DESCRIPTION
##### Change logging to `System` in error frame
We don't have a handler to call logging methods on, so just use Java's
built-in `System.out` calls.